### PR TITLE
Restrict field creation to admin roles and add role constants

### DIFF
--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -42,6 +42,8 @@ class FieldController extends Controller
      */
     public function store(Request $request)
     {
+        $this->authorize('create', Field::class);
+
         $data = $request->validate([
             'club_id' => 'required|exists:clubs,id',
             'name' => 'required|string',

--- a/backend/app/Http/Controllers/Controller.php
+++ b/backend/app/Http/Controllers/Controller.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/backend/app/Http/Middleware/EnsureUserHasRole.php
+++ b/backend/app/Http/Middleware/EnsureUserHasRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class EnsureUserHasRole
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next, ...$roles)
+    {
+        $user = $request->user();
+
+        if (! $user || ! in_array($user->role, $roles, true)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -13,6 +13,10 @@ class User extends Authenticatable
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
 
+    public const ROLE_SUPERADMIN = 'superadmin';
+    public const ROLE_ADMIN = 'admin';
+    public const ROLE_CLIENTE = 'cliente';
+
     /**
      * The attributes that are mass assignable.
      *

--- a/backend/app/Policies/FieldPolicy.php
+++ b/backend/app/Policies/FieldPolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Field;
+
+class FieldPolicy
+{
+    /**
+     * Determine whether the user can create fields.
+     */
+    public function create(User $user): bool
+    {
+        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use App\Models\Field;
+use App\Policies\FieldPolicy;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +22,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::policy(Field::class, FieldPolicy::class);
     }
 }

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\EnsureUserHasRole::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/backend/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/backend/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->enum('role', ['superadmin', 'admin', 'client'])->default('client');
+            $table->enum('role', ['superadmin', 'admin', 'cliente'])->default('cliente');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,8 +9,11 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 
 Route::get('/fields', [FieldController::class, 'index']);
-Route::post('/fields', [FieldController::class, 'store'])->middleware('auth:sanctum');
 Route::get('/fields/{field}', [FieldController::class, 'show']);
+
+Route::middleware(['auth:sanctum', 'role:admin,superadmin'])->group(function () {
+    Route::post('/fields', [FieldController::class, 'store']);
+});
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);


### PR DESCRIPTION
## Summary
- add role constants to User model and default `cliente` role in users table
- implement role middleware and policy for field creation
- protect field creation route for admin and superadmin

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68a6500764f88320be736740b5cade70