### PR TITLE
Add role-protected field update and deletion

### DIFF
--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -69,16 +69,30 @@ class FieldController extends Controller
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, string $id)
+    public function update(Request $request, Field $field)
     {
-        //
+        $data = $request->validate([
+            'club_id' => 'sometimes|exists:clubs,id',
+            'name' => 'sometimes|string',
+            'sport' => 'sometimes|in:futbol,padel',
+            'surface' => 'nullable|string',
+            'is_indoor' => 'boolean',
+            'price_per_hour' => 'sometimes|numeric',
+            'features' => 'array',
+        ]);
+
+        $field->update($data);
+
+        return response()->json($field);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(string $id)
+    public function destroy(Field $field)
     {
-        //
+        $field->delete();
+
+        return response()->json(null, 204);
     }
 }

--- a/backend/app/Http/Middleware/RoleMiddleware.php
+++ b/backend/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class RoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  string  ...$roles
+     */
+    public function handle(Request $request, Closure $next, string ...$roles)
+    {
+        $user = $request->user();
+
+        if (! $user || ! in_array($user->role, $roles)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,8 +9,14 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 
 Route::get('/fields', [FieldController::class, 'index']);
-Route::post('/fields', [FieldController::class, 'store'])->middleware('auth:sanctum');
 Route::get('/fields/{field}', [FieldController::class, 'show']);
+
+Route::middleware(['auth:sanctum', 'role:admin,superadmin'])->group(function () {
+    Route::post('/fields', [FieldController::class, 'store']);
+    Route::put('/fields/{field}', [FieldController::class, 'update']);
+    Route::patch('/fields/{field}', [FieldController::class, 'update']);
+    Route::delete('/fields/{field}', [FieldController::class, 'destroy']);
+});
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);

--- a/backend/tests/Feature/FieldManagementTest.php
+++ b/backend/tests/Feature/FieldManagementTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Models\{User, Club, Field};
+
+class FieldManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createField(User $user): Field
+    {
+        $club = Club::create([
+            'user_id' => $user->id,
+            'name' => 'Club',
+            'address' => 'Addr',
+            'city' => 'City',
+            'latitude' => 0,
+            'longitude' => 0,
+        ]);
+
+        return Field::create([
+            'club_id' => $club->id,
+            'name' => 'Field',
+            'sport' => 'futbol',
+            'price_per_hour' => 100,
+        ]);
+    }
+
+    public function test_admin_can_update_field(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $field = $this->createField($admin);
+
+        $token = $admin->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->putJson('/api/fields/'.$field->id, [
+                'name' => 'Updated Field',
+            ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('fields', [
+            'id' => $field->id,
+            'name' => 'Updated Field',
+        ]);
+    }
+
+    public function test_client_cannot_update_field(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $field = $this->createField($admin);
+        $client = User::factory()->create();
+
+        $token = $client->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->putJson('/api/fields/'.$field->id, [
+                'name' => 'Updated Field',
+            ]);
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_can_delete_field(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $field = $this->createField($admin);
+
+        $token = $admin->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->deleteJson('/api/fields/'.$field->id);
+
+        $response->assertStatus(204);
+        $this->assertDatabaseMissing('fields', [
+            'id' => $field->id,
+        ]);
+    }
+
+    public function test_client_cannot_delete_field(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $field = $this->createField($admin);
+        $client = User::factory()->create();
+
+        $token = $client->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer '.$token)
+            ->deleteJson('/api/fields/'.$field->id);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('fields', [
+            'id' => $field->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- implement update and destroy logic for fields
- add role-based middleware and protect field modification routes
- add feature tests for field updates and deletions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a6500cecd88320b517632863488ecc