### PR TITLE
feat: add reservation payment support

### DIFF
--- a/backend/app/Http/Controllers/Api/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/ReservationController.php
@@ -7,6 +7,7 @@ use App\Models\Field;
 use App\Models\Reservation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use App\Services\PaymentService;
 
 class ReservationController extends Controller
 {
@@ -78,6 +79,17 @@ class ReservationController extends Controller
 
         $reservation->status = 'cancelled';
         $reservation->save();
+
+        return response()->json($reservation);
+    }
+
+    public function pay(Reservation $reservation, PaymentService $paymentService)
+    {
+        if ($reservation->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $paymentService->payReservation($reservation);
 
         return response()->json($reservation);
     }

--- a/backend/app/Models/Reservation.php
+++ b/backend/app/Models/Reservation.php
@@ -14,13 +14,13 @@ class Reservation extends Model
         'end_time',
         'price',
         'status',
-        'paid',
+        'payment_status',
     ];
 
     protected $casts = [
         'start_time' => 'datetime',
         'end_time' => 'datetime',
-        'paid' => 'boolean',
+        'payment_status' => 'string',
     ];
 
     public function field(): BelongsTo

--- a/backend/app/Services/PaymentService.php
+++ b/backend/app/Services/PaymentService.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Reservation;
+
+class PaymentService
+{
+    public function payReservation(Reservation $reservation): Reservation
+    {
+        // Here we would integrate with MercadoPago or another provider
+        // For now we simply mark the reservation as paid
+        $reservation->payment_status = 'paid';
+        $reservation->save();
+
+        return $reservation;
+    }
+}

--- a/backend/database/migrations/2025_08_20_213715_create_reservations_table.php
+++ b/backend/database/migrations/2025_08_20_213715_create_reservations_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->timestamp('end_time');
             $table->decimal('price', 8, 2);
             $table->enum('status', ['pending', 'confirmed', 'cancelled'])->default('pending');
-            $table->boolean('paid')->default(false);
+            $table->enum('payment_status', ['pending', 'paid', 'failed'])->default('pending');
             $table->timestamps();
         });
     }

--- a/backend/resources/js/app.js
+++ b/backend/resources/js/app.js
@@ -1,1 +1,15 @@
 import './bootstrap';
+import axios from 'axios';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const list = document.getElementById('reservations');
+    if (list) {
+        axios.get('/api/reservations').then(res => {
+            res.data.forEach(r => {
+                const li = document.createElement('li');
+                li.textContent = `${r.field.name} - ${r.payment_status}`;
+                list.appendChild(li);
+            });
+        });
+    }
+});

--- a/backend/resources/views/panel.blade.php
+++ b/backend/resources/views/panel.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Panel de Club</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+  </head>
+  <body>
+    <h1>Reservas</h1>
+    <ul id="reservations"></ul>
+  </body>
+</html>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -17,4 +17,5 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/reservations', [ReservationController::class, 'store']);
     Route::get('/reservations/{reservation}', [ReservationController::class, 'show']);
     Route::delete('/reservations/{reservation}', [ReservationController::class, 'destroy']);
+    Route::post('/reservations/{reservation}/pay', [ReservationController::class, 'pay']);
 });

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/panel', function () {
+    return view('panel');
+});

--- a/backend/tests/Feature/ReservationCancellationTest.php
+++ b/backend/tests/Feature/ReservationCancellationTest.php
@@ -34,7 +34,7 @@ class ReservationCancellationTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
         $token = $user->createToken('test')->plainTextToken;
@@ -74,7 +74,7 @@ class ReservationCancellationTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
         $token = $user->createToken('test')->plainTextToken;

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -2,27 +2,27 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList } from 'react-native';
 
 export default function App() {
-  const [fields, setFields] = useState([]);
+  const [reservations, setReservations] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:8000/api/fields')
+    fetch('http://localhost:8000/api/reservations')
       .then((res) => res.json())
-      .then((json) => setFields(json.data || []))
+      .then((json) => setReservations(json || []))
       .catch((err) => console.log(err));
   }, []);
 
   return (
     <View style={{ flex: 1, paddingTop: 50, paddingHorizontal: 16 }}>
       <Text style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 12 }}>
-        Canchas disponibles
+        Mis reservas
       </Text>
       <FlatList
-        data={fields}
+        data={reservations}
         keyExtractor={(item) => item.id.toString()}
         renderItem={({ item }) => (
-          <Text>{item.name} - {item.sport}</Text>
+          <Text>{item.field?.name} - {item.payment_status}</Text>
         )}
-        ListEmptyComponent={<Text>No hay canchas</Text>}
+        ListEmptyComponent={<Text>No hay reservas</Text>}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- add PaymentService to handle reservation payments
- support payment status on reservations and expose /reservations/{id}/pay
- show payment status in mobile app and club panel

## Testing
- `cd backend && composer test`

------
https://chatgpt.com/codex/tasks/task_e_68a65016d8cc832080d8b8ddf1a06622