### PR TITLE
Implement role enums and field/club access policies

### DIFF
--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -135,6 +135,8 @@ class FieldController extends Controller
      */
     public function update(Request $request, Field $field)
     {
+        $this->authorize('update', $field);
+
         $data = $request->validate([
             'club_id' => 'sometimes|exists:clubs,id',
             'name' => 'sometimes|string',
@@ -155,6 +157,8 @@ class FieldController extends Controller
      */
     public function destroy(Field $field)
     {
+        $this->authorize('delete', $field);
+
         $field->delete();
 
         return response()->json(null, 204);

--- a/backend/app/Http/Middleware/EnsureUserHasRole.php
+++ b/backend/app/Http/Middleware/EnsureUserHasRole.php
@@ -14,7 +14,7 @@ class EnsureUserHasRole
     {
         $user = $request->user();
 
-        if (! $user || ! in_array($user->role, $roles, true)) {
+        if (! $user || ! in_array($user->role->value, $roles, true)) {
             abort(403);
         }
 

--- a/backend/app/Http/Middleware/RoleMiddleware.php
+++ b/backend/app/Http/Middleware/RoleMiddleware.php
@@ -17,7 +17,7 @@ class RoleMiddleware
     {
         $user = $request->user();
 
-        if (! $user || ! in_array($user->role, $roles)) {
+        if (! $user || ! in_array($user->role->value, $roles, true)) {
             abort(403);
         }
 

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -8,14 +8,17 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+enum Role: string
+{
+    case SUPERADMIN = 'superadmin';
+    case ADMIN = 'admin';
+    case CLIENTE = 'cliente';
+}
+
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
-
-    public const ROLE_SUPERADMIN = 'superadmin';
-    public const ROLE_ADMIN = 'admin';
-    public const ROLE_CLIENTE = 'cliente';
 
     /**
      * The attributes that are mass assignable.
@@ -50,7 +53,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
-            'role' => 'string',
+            'role' => Role::class,
         ];
     }
 

--- a/backend/app/Policies/ClubPolicy.php
+++ b/backend/app/Policies/ClubPolicy.php
@@ -2,24 +2,21 @@
 
 namespace App\Policies;
 
-use App\Models\{Field, Role, User};
+use App\Models\{Club, Role, User};
 
-class FieldPolicy
+class ClubPolicy
 {
-    /**
-     * Determine whether the user can create fields.
-     */
     public function create(User $user): bool
     {
         return in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
     }
 
-    public function update(User $user, Field $field): bool
+    public function update(User $user, Club $club): bool
     {
         return in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
     }
 
-    public function delete(User $user, Field $field): bool
+    public function delete(User $user, Club $club): bool
     {
         return in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
     }

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,10 +2,10 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Gate;
-use App\Models\Field;
-use App\Policies\FieldPolicy;
+use Illuminate\Support\ServiceProvider;
+use App\Models\{Club, Field};
+use App\Policies\{ClubPolicy, FieldPolicy};
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,5 +23,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Gate::policy(Field::class, FieldPolicy::class);
+        Gate::policy(Club::class, ClubPolicy::class);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,14 +5,20 @@ use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ReviewController;
+use App\Models\Field;
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
 
 Route::get('/fields', [FieldController::class, 'index']);
 Route::get('/fields/map', [FieldController::class, 'map']);
-Route::post('/fields', [FieldController::class, 'store'])->middleware('auth:sanctum');
+Route::post('/fields', [FieldController::class, 'store'])
+    ->middleware(['auth:sanctum', 'can:create,' . Field::class]);
 Route::get('/fields/{field}', [FieldController::class, 'show']);
+Route::put('/fields/{field}', [FieldController::class, 'update'])
+    ->middleware(['auth:sanctum', 'can:update,field']);
+Route::delete('/fields/{field}', [FieldController::class, 'destroy'])
+    ->middleware(['auth:sanctum', 'can:delete,field']);
 
 Route::get('/reviews', [ReviewController::class, 'index']);
 Route::get('/reviews/{review}', [ReviewController::class, 'show']);


### PR DESCRIPTION
## Summary
- Define `Role` enum in `User` model and cast `role` attribute
- Add policies for managing fields and clubs
- Protect field routes with authorization middleware

## Testing
- `composer test` *(fails: FieldAvailabilityTest, ReservationIcsTest, ReservationPaymentTest)*

------
https://chatgpt.com/codex/tasks/task_e_68a659d180648320a150ec5f401e653d