### PR TITLE
Enable reservation rescheduling and shared costs

### DIFF
--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -17,6 +17,8 @@ class FieldController extends Controller
             ->with('club')
             ->withAvg('reviews as average_rating', 'rating');
 
+        $this->applyFilters($fields, $request);
+
         return response()->json($fields->paginate());
     }
 
@@ -135,6 +137,8 @@ class FieldController extends Controller
      */
     public function update(Request $request, Field $field)
     {
+        $this->authorize('update', $field);
+
         $data = $request->validate([
             'club_id' => 'sometimes|exists:clubs,id',
             'name' => 'sometimes|string',
@@ -155,6 +159,8 @@ class FieldController extends Controller
      */
     public function destroy(Field $field)
     {
+        $this->authorize('delete', $field);
+
         $field->delete();
 
         return response()->json(null, 204);

--- a/backend/app/Http/Controllers/Api/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/ReservationController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\Field;
 use App\Models\Reservation;
+use App\Models\SharedCost;
 use App\Jobs\SendReservationReminder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -99,6 +100,18 @@ class ReservationController extends Controller
             'end_time' => 'required|date|after:start_time',
         ]);
 
+        $conflict = Reservation::where('field_id', $reservation->field_id)
+            ->where('id', '!=', $reservation->id)
+            ->where(function ($query) use ($data) {
+                $query->where('start_time', '<', $data['end_time'])
+                    ->where('end_time', '>', $data['start_time']);
+            })
+            ->exists();
+
+        if ($conflict) {
+            return response()->json(['message' => 'Field is already booked for that time'], 422);
+        }
+
         $field = $reservation->field;
         $hours = (strtotime($data['end_time']) - strtotime($data['start_time'])) / 3600;
         $price = $field->price_per_hour * $hours;
@@ -109,6 +122,28 @@ class ReservationController extends Controller
         $reservation->save();
 
         return response()->json($reservation);
+    }
+
+    public function addParticipant(Request $request, Reservation $reservation)
+    {
+        if ($reservation->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $data = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'amount' => 'required|numeric|min:0',
+        ]);
+
+        $reservation->participants()->attach($data['user_id'], ['amount' => $data['amount']]);
+
+        SharedCost::create([
+            'reservation_id' => $reservation->id,
+            'user_id' => $data['user_id'],
+            'amount' => $data['amount'],
+        ]);
+
+        return response()->json(['message' => 'Participant added'], 201);
     }
 
     /**

--- a/backend/app/Models/Reservation.php
+++ b/backend/app/Models/Reservation.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Carbon\Carbon;
 
 class Reservation extends Model
@@ -38,8 +39,14 @@ class Reservation extends Model
     public function participants(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'reservation_participants')
+            ->using(ReservationParticipant::class)
             ->withPivot('amount')
             ->withTimestamps();
+    }
+
+    public function sharedCosts(): HasMany
+    {
+        return $this->hasMany(SharedCost::class);
     }
 
     public static function createPeriodic(array $data, int $count): array

--- a/backend/app/Models/ReservationParticipant.php
+++ b/backend/app/Models/ReservationParticipant.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class ReservationParticipant extends Pivot
+{
+    protected $table = 'reservation_participants';
+
+    protected $fillable = [
+        'reservation_id',
+        'user_id',
+        'amount',
+    ];
+
+    public function reservation(): BelongsTo
+    {
+        return $this->belongsTo(Reservation::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/SharedCost.php
+++ b/backend/app/Models/SharedCost.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SharedCost extends Model
+{
+    protected $table = 'reservation_shared_costs';
+
+    protected $fillable = [
+        'reservation_id',
+        'user_id',
+        'amount',
+    ];
+
+    public function reservation(): BelongsTo
+    {
+        return $this->belongsTo(Reservation::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Policies/FieldPolicy.php
+++ b/backend/app/Policies/FieldPolicy.php
@@ -14,4 +14,14 @@ class FieldPolicy
     {
         return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
     }
+
+    public function update(User $user, Field $field): bool
+    {
+        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
+    }
+
+    public function delete(User $user, Field $field): bool
+    {
+        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
+    }
 }

--- a/backend/database/migrations/2025_08_20_220001_create_shared_costs_table.php
+++ b/backend/database/migrations/2025_08_20_220001_create_shared_costs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('reservation_shared_costs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 8, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_shared_costs');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -12,6 +12,8 @@ Route::post('/login', [AuthController::class, 'login']);
 Route::get('/fields', [FieldController::class, 'index']);
 Route::get('/fields/map', [FieldController::class, 'map']);
 Route::post('/fields', [FieldController::class, 'store'])->middleware('auth:sanctum');
+Route::put('/fields/{field}', [FieldController::class, 'update'])->middleware('auth:sanctum');
+Route::delete('/fields/{field}', [FieldController::class, 'destroy'])->middleware('auth:sanctum');
 Route::get('/fields/{field}', [FieldController::class, 'show']);
 
 Route::get('/reviews', [ReviewController::class, 'index']);
@@ -23,6 +25,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations/{reservation}', [ReservationController::class, 'show']);
     Route::put('/reservations/{reservation}', [ReservationController::class, 'update']);
     Route::delete('/reservations/{reservation}', [ReservationController::class, 'destroy']);
+    Route::post('/reservations/{reservation}/pay', [ReservationController::class, 'pay']);
+    Route::get('/reservations/{reservation}/ics', [ReservationController::class, 'ics']);
+    Route::post('/reservations/{reservation}/participants', [ReservationController::class, 'addParticipant']);
     Route::post('/reviews', [ReviewController::class, 'store']);
     Route::put('/reviews/{review}', [ReviewController::class, 'update']);
     Route::delete('/reviews/{review}', [ReviewController::class, 'destroy']);

--- a/backend/tests/Feature/ReservationIcsTest.php
+++ b/backend/tests/Feature/ReservationIcsTest.php
@@ -34,7 +34,7 @@ class ReservationIcsTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
         $token = $user->createToken('test')->plainTextToken;

--- a/backend/tests/Feature/ReservationParticipantsTest.php
+++ b/backend/tests/Feature/ReservationParticipantsTest.php
@@ -35,12 +35,25 @@ class ReservationParticipantsTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
-        $reservation->participants()->attach($participant->id, ['amount' => 50]);
+        $token = $owner->createToken('test')->plainTextToken;
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->postJson('/api/reservations/' . $reservation->id . '/participants', [
+                'user_id' => $participant->id,
+                'amount' => 50,
+            ]);
+
+        $response->assertStatus(201);
 
         $this->assertDatabaseHas('reservation_participants', [
+            'reservation_id' => $reservation->id,
+            'user_id' => $participant->id,
+            'amount' => 50,
+        ]);
+
+        $this->assertDatabaseHas('reservation_shared_costs', [
             'reservation_id' => $reservation->id,
             'user_id' => $participant->id,
             'amount' => 50,

--- a/backend/tests/Feature/ReservationPeriodicTest.php
+++ b/backend/tests/Feature/ReservationPeriodicTest.php
@@ -35,7 +35,7 @@ class ReservationPeriodicTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ];
 
         Reservation::createPeriodic($data, 3);

--- a/backend/tests/Feature/ReservationRescheduleTest.php
+++ b/backend/tests/Feature/ReservationRescheduleTest.php
@@ -34,7 +34,7 @@ class ReservationRescheduleTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
         $token = $user->createToken('test')->plainTextToken;
@@ -79,7 +79,7 @@ class ReservationRescheduleTest extends TestCase
             'end_time' => '2025-08-21 11:00:00',
             'price' => 100,
             'status' => 'confirmed',
-            'paid' => false,
+            'payment_status' => 'pending',
         ]);
 
         $token = $user->createToken('test')->plainTextToken;


### PR DESCRIPTION
## Summary
- Allow reservations to be rescheduled with price recalculation and conflict checks
- Track participants and their shared costs via new models and migration
- Add authenticated endpoints for paying, exporting, and sharing reservation costs

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68a659dce0a88320bb8a5692103fa92c