### PR TITLE
Add map filters and mobile markers

### DIFF
--- a/backend/app/Http/Controllers/Api/FieldController.php
+++ b/backend/app/Http/Controllers/Api/FieldController.php
@@ -13,9 +13,9 @@ class FieldController extends Controller
      */
     public function index(Request $request)
     {
-        $fields = Field::query()
-            ->with('club')
-            ->withAvg('reviews as average_rating', 'rating');
+        $fields = Field::query()->with('club');
+        $this->applyFilters($fields, $request);
+        $fields->withAvg('reviews as average_rating', 'rating');
 
         return response()->json($fields->paginate());
     }

--- a/backend/database/migrations/2025_08_20_213710_create_clubs_table.php
+++ b/backend/database/migrations/2025_08_20_213710_create_clubs_table.php
@@ -17,8 +17,8 @@ return new class extends Migration
             $table->string('name');
             $table->string('address');
             $table->string('city');
-            $table->decimal('latitude', 10, 7)->nullable();
-            $table->decimal('longitude', 10, 7)->nullable();
+            $table->decimal('latitude', 10, 7)->nullable()->index();
+            $table->decimal('longitude', 10, 7)->nullable()->index();
             $table->timestamps();
         });
     }

--- a/backend/database/migrations/2025_08_20_213713_create_fields_table.php
+++ b/backend/database/migrations/2025_08_20_213713_create_fields_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
             $table->enum('sport', ['futbol', 'padel']);
             $table->string('surface')->nullable();
             $table->boolean('is_indoor')->default(false);
-            $table->decimal('latitude', 10, 7)->nullable();
-            $table->decimal('longitude', 10, 7)->nullable();
+            $table->decimal('latitude', 10, 7)->nullable()->index();
+            $table->decimal('longitude', 10, 7)->nullable()->index();
             $table->decimal('price_per_hour', 8, 2);
             $table->json('features')->nullable();
             $table->timestamps();

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -10,6 +10,7 @@ import FieldListScreen from './screens/FieldListScreen';
 import FieldDetailScreen from './screens/FieldDetailScreen';
 import ReservationsScreen from './screens/ReservationsScreen';
 import FiltersScreen from './screens/FiltersScreen';
+import FieldMapScreen from './screens/FieldMapScreen';
 
 const RootStack = createNativeStackNavigator();
 const FieldsStack = createNativeStackNavigator();
@@ -22,6 +23,7 @@ function FieldsStackScreen() {
       <FieldsStack.Screen name="Fields" component={FieldListScreen} options={{ title: 'Canchas' }} />
       <FieldsStack.Screen name="FieldDetail" component={FieldDetailScreen} options={{ title: 'Detalle' }} />
       <FieldsStack.Screen name="Filters" component={FiltersScreen} options={{ title: 'Filtros' }} />
+      <FieldsStack.Screen name="FieldMap" component={FieldMapScreen} options={{ title: 'Mapa' }} />
     </FieldsStack.Navigator>
   );
 }

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "^49.0.0",
         "react": "18.2.0",
         "react-native": "0.74.0",
+        "react-native-maps": "1.8.0",
         "react-native-safe-area-context": "4.5.0",
         "react-native-screens": "~3.20.0"
       }
@@ -5423,6 +5424,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -12266,6 +12273,25 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.8.0.tgz",
+      "integrity": "sha512-KfVZ03L42+a22Fkcl2uDe5d+73BweTlcRUzm2G+aQUJ7fHrBxj7CuXWtKMSNpVDiO3YDCWcshiiyjSXxkd/qOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
           "optional": true
         }
       }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,6 +15,7 @@
     "expo": "^49.0.0",
     "react": "18.2.0",
     "react-native": "0.74.0",
+    "react-native-maps": "1.8.0",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0"
   }

--- a/mobile/screens/FieldListScreen.js
+++ b/mobile/screens/FieldListScreen.js
@@ -23,10 +23,16 @@ export default function FieldListScreen({ navigation, route }) {
   useLayoutEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Button
-          title="Filtros"
-          onPress={() => navigation.navigate('Filters', { sport, city })}
-        />
+        <View style={{ flexDirection: 'row' }}>
+          <Button
+            title="Mapa"
+            onPress={() => navigation.navigate('FieldMap', { sport, city })}
+          />
+          <Button
+            title="Filtros"
+            onPress={() => navigation.navigate('Filters', { sport, city })}
+          />
+        </View>
       ),
     });
   }, [navigation, sport, city]);

--- a/mobile/screens/FieldMapScreen.js
+++ b/mobile/screens/FieldMapScreen.js
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from 'react';
+import { View, ActivityIndicator } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+
+export default function FieldMapScreen({ route }) {
+  const [fields, setFields] = useState([]);
+  const sport = route.params?.sport;
+  const city = route.params?.city;
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (sport) params.append('sport', sport);
+    if (city) params.append('city', city);
+    fetch(`http://localhost:8000/api/fields/map?${params.toString()}`)
+      .then((res) => res.json())
+      .then(setFields)
+      .catch(() => setFields([]));
+  }, [sport, city]);
+
+  if (fields.length === 0) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  const initial = fields[0];
+  const initialRegion = {
+    latitude: initial.latitude,
+    longitude: initial.longitude,
+    latitudeDelta: 0.1,
+    longitudeDelta: 0.1,
+  };
+
+  return (
+    <MapView style={{ flex: 1 }} initialRegion={initialRegion}>
+      {fields.map((field) => (
+        <Marker
+          key={field.id}
+          coordinate={{ latitude: field.latitude, longitude: field.longitude }}
+          title={field.name}
+        />
+      ))}
+    </MapView>
+  );
+}


### PR DESCRIPTION
## Summary
- index clubs and fields by latitude/longitude
- support distance, surface, indoor and price filters in FieldController index
- show field markers on a new map screen in the mobile app

## Testing
- `php artisan test` *(fails: Please provide a valid cache path)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a659e32a748320ad49ea95e8bbb8bc