### PR TITLE
feat: add push notifications and calendar export

### DIFF
--- a/backend/app/Http/Controllers/Api/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/ReservationController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Field;
 use App\Models\Reservation;
 use App\Jobs\SendReservationReminder;
+use App\Jobs\SendPushNotification;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Services\PaymentService;
@@ -108,6 +109,12 @@ class ReservationController extends Controller
         $reservation->price = $price;
         $reservation->save();
 
+        SendPushNotification::dispatch(
+            $reservation->user,
+            'Reserva actualizada',
+            'Tu reserva fue modificada'
+        );
+
         return response()->json($reservation);
     }
 
@@ -122,6 +129,12 @@ class ReservationController extends Controller
 
         $reservation->status = 'cancelled';
         $reservation->save();
+
+        SendPushNotification::dispatch(
+            $reservation->user,
+            'Reserva cancelada',
+            'Tu reserva fue cancelada'
+        );
 
         return response()->json($reservation);
     }

--- a/backend/app/Jobs/SendPushNotification.php
+++ b/backend/app/Jobs/SendPushNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class SendPushNotification implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public User $user,
+        public string $title,
+        public string $body,
+        public array $data = []
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $user = $this->user->fresh();
+        if (! $user || ! $user->fcm_token) {
+            return;
+        }
+
+        Http::withToken(config('services.fcm.key'))
+            ->post('https://fcm.googleapis.com/fcm/send', [
+                'to' => $user->fcm_token,
+                'notification' => [
+                    'title' => $this->title,
+                    'body' => $this->body,
+                ],
+                'data' => $this->data,
+            ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -21,9 +21,11 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);
     Route::post('/reservations', [ReservationController::class, 'store']);
     Route::get('/reservations/{reservation}', [ReservationController::class, 'show']);
+    Route::get('/reservations/{reservation}/ics', [ReservationController::class, 'ics']);
     Route::put('/reservations/{reservation}', [ReservationController::class, 'update']);
     Route::delete('/reservations/{reservation}', [ReservationController::class, 'destroy']);
     Route::post('/reviews', [ReviewController::class, 'store']);
     Route::put('/reviews/{review}', [ReviewController::class, 'update']);
     Route::delete('/reviews/{review}', [ReviewController::class, 'destroy']);
+    Route::post('/fcm-token', [AuthController::class, 'updateFcmToken']);
 });

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,9 +1,10 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { View, Text } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { AuthProvider, AuthContext } from './context/AuthContext';
+import { registerForPushNotificationsAsync } from './src/notifications';
 import LoginScreen from './screens/LoginScreen';
 import RegisterScreen from './screens/RegisterScreen';
 import FieldListScreen from './screens/FieldListScreen';
@@ -45,6 +46,12 @@ function AppTabs() {
 
 function RootNavigator() {
   const { token, loading } = useContext(AuthContext);
+
+  useEffect(() => {
+    if (token) {
+      registerForPushNotificationsAsync(token);
+    }
+  }, [token]);
   if (loading) {
     return (
       <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -13,6 +13,7 @@
         "@react-navigation/native": "^6.1.6",
         "@react-navigation/native-stack": "^6.9.12",
         "expo": "^49.0.0",
+        "expo-notifications": "^0.24.2",
         "react": "18.2.0",
         "react-native": "0.74.0",
         "react-native-safe-area-context": "4.5.0",
@@ -2570,6 +2571,24 @@
         "getenv": "^1.0.0"
       }
     },
+    "node_modules/@expo/fingerprint": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.2.0.tgz",
+      "integrity": "sha512-k6MhJTrX4CYEwsyGemiLT8rnBwjRBYe0eKYAM3kqw0WbSHzkOJm739sgdswGLmA53iiX6FbB1TsiLnqt+h2U2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.5.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "find-up": "^5.0.0",
+        "minimatch": "^3.0.4",
+        "p-limit": "^3.1.0",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "fingerprint": "bin/cli.js"
+      }
+    },
     "node_modules/@expo/image-utils": {
       "version": "0.3.22",
       "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.3.22.tgz",
@@ -3064,6 +3083,12 @@
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
+    },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5745,6 +5770,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
@@ -5962,6 +6000,12 @@
         "babel-plugin-react-native-web": "~0.18.10",
         "metro-react-native-babel-preset": "0.76.8"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -7609,6 +7653,177 @@
         "invariant": "^2.2.4"
       }
     },
+    "node_modules/expo-notifications": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.24.2.tgz",
+      "integrity": "sha512-sDqg4lUqEGINVjTPWAhqe9zit3oIyK7vwZS2+GYyL2cDqFKWF9vqhZ/yChS3VHgu/h5F349okkUiwQUcZIw07Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.3.18",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~5.5.0",
+        "expo-constants": "~15.1.0",
+        "fs-extra": "^9.1.0",
+        "uuid": "^3.4.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-8.3.1.tgz",
+      "integrity": "sha512-5fNGAw5h/MDOc8Ulv9nonafPtOT042B7dF6vrVxSP3CY5qiVu0tCsmbL412wEcrAZ8MY7UMv9e6IzpGTgleYgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~7.5.0",
+        "@expo/config-types": "^50.0.0-alpha.1",
+        "@expo/json-file": "^8.2.37",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.5.3",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-plugins": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-7.5.0.tgz",
+      "integrity": "sha512-qOKjmgbddLh1vj9ytUT6AduhEans2cHgS42nopVgh5Wz8X+QUvPcCr1Yc8MvLM3OlbswBMCJceeosZa463i0uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^50.0.0-alpha.1",
+        "@expo/fingerprint": "^0.2.0",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "@react-native/normalize-color": "^2.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.1",
+        "find-up": "~5.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "slash": "^3.0.0",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/config-types": {
+      "version": "50.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-50.0.1.tgz",
+      "integrity": "sha512-EZHMgzkWRB9SMHO1e9m8s+OMahf92XYTnsCFjxhSfcDrcEoSdFPyJWDJVloHZPMGhxns7Fi2+A+bEVN/hD4NKA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-notifications/node_modules/@expo/json-file": {
+      "version": "8.2.37",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.2.37.tgz",
+      "integrity": "sha512-YaH6rVg11JoTS2P6LsW7ybS2CULjf40AbnAHw2F1eDPuheprNjARZMnyHFPkKv7GuxCy+B9GPcbOKgc4cgA80Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.2",
+        "write-file-atomic": "^2.3.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/expo-application": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-5.5.0.tgz",
+      "integrity": "sha512-Km+awHNDTqLv/m7YWLutr/DCWRVZ1mXBsgVyJbUhHtxcVj/XW5AzesZ6Y6TeB8BkW4M209PWC1HhsZ7Z8Kx/HQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/expo-constants": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-15.1.0.tgz",
+      "integrity": "sha512-+06kR3OaE5C/szTwuztID+bINo1UUOn2gYzMpUcKJVyLWFiogxwhVcX1NL4qVKRlN2kCyHQehHMVVtjkOrKldw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~8.3.0",
+        "uuid": "^3.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -8638,6 +8853,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -8911,6 +9142,22 @@
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -11273,6 +11520,22 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -14363,6 +14626,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native": "^6.1.6",
     "@react-navigation/native-stack": "^6.9.12",
     "expo": "^49.0.0",
+    "expo-notifications": "^0.24.2",
     "react": "18.2.0",
     "react-native": "0.74.0",
     "react-native-safe-area-context": "4.5.0",

--- a/mobile/src/notifications.js
+++ b/mobile/src/notifications.js
@@ -1,0 +1,27 @@
+import * as Notifications from 'expo-notifications';
+
+export async function registerForPushNotificationsAsync(authToken) {
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== 'granted') {
+    return;
+  }
+
+  const tokenData = await Notifications.getDevicePushTokenAsync();
+  const fcmToken = tokenData.data;
+
+  await fetch('http://localhost:8000/api/fcm-token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ fcm_token: fcmToken }),
+  });
+
+  return fcmToken;
+}


### PR DESCRIPTION
## Summary
- queue generic Firebase push notifications
- expose ICS download and FCM token routes
- subscribe mobile app to push notifications

## Testing
- `composer test` *(fails: Tests\Feature\FieldAvailabilityTest > filters fields by availability, Tests\Feature\FieldManagementTest, Tests\Feature\ReservationPaymentTest)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a659e7e7a08320adc46911facc5215