### PR TITLE
Add basic chat system and user ranking

### DIFF
--- a/backend/app/Events/MessageSent.php
+++ b/backend/app/Events/MessageSent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Message;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageSent implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Message $message)
+    {
+    }
+
+    public function broadcastOn(): Channel
+    {
+        return new Channel('chat.' . $this->message->chat_id);
+    }
+
+    public function broadcastWith(): array
+    {
+        return [
+            'id' => $this->message->id,
+            'chat_id' => $this->message->chat_id,
+            'user_id' => $this->message->user_id,
+            'content' => $this->message->content,
+            'created_at' => $this->message->created_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/Api/ChatController.php
+++ b/backend/app/Http/Controllers/Api/ChatController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Chat;
+use Illuminate\Http\Request;
+
+class ChatController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Chat::with('users')->get());
+    }
+
+    public function show(Chat $chat)
+    {
+        return response()->json($chat->load('users'));
+    }
+}

--- a/backend/app/Http/Controllers/Api/MessageController.php
+++ b/backend/app/Http/Controllers/Api/MessageController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Events\MessageSent;
+use App\Http\Controllers\Controller;
+use App\Models\Chat;
+use App\Models\Message;
+use Illuminate\Http\Request;
+
+class MessageController extends Controller
+{
+    public function index(Chat $chat)
+    {
+        return response()->json($chat->messages()->with('user')->get());
+    }
+
+    public function store(Request $request, Chat $chat)
+    {
+        $data = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'content' => 'required|string',
+        ]);
+
+        $message = $chat->messages()->create($data);
+
+        MessageSent::dispatch($message);
+
+        return response()->json($message, 201);
+    }
+}

--- a/backend/app/Http/Controllers/Api/UserController.php
+++ b/backend/app/Http/Controllers/Api/UserController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function ranking()
+    {
+        $users = User::orderByDesc('points')->get(['id', 'name', 'points']);
+
+        return response()->json($users);
+    }
+}

--- a/backend/app/Models/Chat.php
+++ b/backend/app/Models/Chat.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Chat extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/backend/app/Models/Message.php
+++ b/backend/app/Models/Message.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['chat_id', 'user_id', 'content'];
+
+    public function chat()
+    {
+        return $this->belongsTo(Chat::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -28,6 +28,7 @@ class User extends Authenticatable
         'password',
         'role',
         'fcm_token',
+        'points',
     ];
 
     /**
@@ -51,6 +52,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'role' => 'string',
+            'points' => 'integer',
         ];
     }
 
@@ -67,5 +69,15 @@ class User extends Authenticatable
     public function reviews()
     {
         return $this->hasMany(Review::class);
+    }
+
+    public function chats()
+    {
+        return $this->belongsToMany(Chat::class);
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
     }
 }

--- a/backend/database/migrations/2025_08_20_220100_create_chats_table.php
+++ b/backend/database/migrations/2025_08_20_220100_create_chats_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('chats', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chats');
+    }
+};

--- a/backend/database/migrations/2025_08_20_220101_create_chat_user_table.php
+++ b/backend/database/migrations/2025_08_20_220101_create_chat_user_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('chat_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_user');
+    }
+};

--- a/backend/database/migrations/2025_08_20_220102_create_messages_table.php
+++ b/backend/database/migrations/2025_08_20_220102_create_messages_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/backend/database/migrations/2025_08_20_220103_add_points_to_users_table.php
+++ b/backend/database/migrations/2025_08_20_220103_add_points_to_users_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('points')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('points');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,9 @@ use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ReviewController;
+use App\Http\Controllers\Api\ChatController;
+use App\Http\Controllers\Api\MessageController;
+use App\Http\Controllers\Api\UserController;
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
@@ -16,6 +19,13 @@ Route::get('/fields/{field}', [FieldController::class, 'show']);
 
 Route::get('/reviews', [ReviewController::class, 'index']);
 Route::get('/reviews/{review}', [ReviewController::class, 'show']);
+
+Route::get('/chats', [ChatController::class, 'index']);
+Route::get('/chats/{chat}', [ChatController::class, 'show']);
+Route::get('/chats/{chat}/messages', [MessageController::class, 'index']);
+Route::post('/chats/{chat}/messages', [MessageController::class, 'store']);
+
+Route::get('/ranking', [UserController::class, 'ranking']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);

--- a/backend/routes/channels.php
+++ b/backend/routes/channels.php
@@ -1,0 +1,7 @@
+<?php
+
+use Illuminate\Support\Facades\Broadcast;
+
+Broadcast::channel('chat.{chatId}', function ($user, $chatId) {
+    return true;
+});

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -10,6 +10,8 @@ import FieldListScreen from './screens/FieldListScreen';
 import FieldDetailScreen from './screens/FieldDetailScreen';
 import ReservationsScreen from './screens/ReservationsScreen';
 import FiltersScreen from './screens/FiltersScreen';
+import ChatListScreen from './screens/ChatListScreen';
+import RankingScreen from './screens/RankingScreen';
 
 const RootStack = createNativeStackNavigator();
 const FieldsStack = createNativeStackNavigator();
@@ -39,6 +41,8 @@ function AppTabs() {
     <Tab.Navigator>
       <Tab.Screen name="Canchas" component={FieldsStackScreen} options={{ headerShown: false }} />
       <Tab.Screen name="Mis reservas" component={ReservationsStackScreen} options={{ headerShown: false }} />
+      <Tab.Screen name="Chats" component={ChatListScreen} />
+      <Tab.Screen name="Ranking" component={RankingScreen} />
     </Tab.Navigator>
   );
 }

--- a/mobile/screens/ChatListScreen.js
+++ b/mobile/screens/ChatListScreen.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+
+export default function ChatListScreen() {
+  const [chats, setChats] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/chats')
+      .then((res) => res.json())
+      .then(setChats)
+      .catch((err) => console.log(err));
+  }, []);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={chats}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <Text style={{ paddingVertical: 8 }}>{item.name || `Chat ${item.id}`}</Text>
+        )}
+        ListEmptyComponent={<Text>No hay chats</Text>}
+      />
+    </View>
+  );
+}

--- a/mobile/screens/RankingScreen.js
+++ b/mobile/screens/RankingScreen.js
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList } from 'react-native';
+
+export default function RankingScreen() {
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/api/ranking')
+      .then((res) => res.json())
+      .then(setUsers)
+      .catch((err) => console.log(err));
+  }, []);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={users}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item, index }) => (
+          <Text style={{ paddingVertical: 8 }}>
+            {index + 1}. {item.name} - {item.points} pts
+          </Text>
+        )}
+        ListEmptyComponent={<Text>No hay usuarios</Text>}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add Chat and Message models with migrations, API endpoints and broadcast event
- track user points and expose ranking endpoint
- display chats and ranking in mobile app tabs

## Testing
- `composer test` *(fails: Tests\Feature\ReservationPaymentTest > user can pay reservation Expected response status code [200] but received 404)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a659fdbbe883208a9c3b2d89276df1