### PR TITLE
feat: add loyalty points and promotions

### DIFF
--- a/backend/app/Http/Controllers/Api/LoyaltyController.php
+++ b/backend/app/Http/Controllers/Api/LoyaltyController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\LoyaltyPoint;
+use App\Models\Promotion;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoyaltyController extends Controller
+{
+    public function balance()
+    {
+        $balance = Auth::user()->loyaltyPoints()->sum('points');
+        return response()->json(['balance' => $balance]);
+    }
+
+    public function redeem(Request $request)
+    {
+        $data = $request->validate([
+            'promotion_id' => 'required|exists:promotions,id',
+        ]);
+
+        $promotion = Promotion::findOrFail($data['promotion_id']);
+        if (!$promotion->is_active) {
+            return response()->json(['message' => 'Promoción no disponible'], 422);
+        }
+
+        $balance = Auth::user()->loyaltyPoints()->sum('points');
+        if ($balance < $promotion->points_required) {
+            return response()->json(['message' => 'Saldo insuficiente'], 422);
+        }
+
+        LoyaltyPoint::create([
+            'user_id' => Auth::id(),
+            'points' => -$promotion->points_required,
+            'description' => 'Redeemed: ' . $promotion->name,
+        ]);
+
+        return response()->json(['balance' => $balance - $promotion->points_required]);
+    }
+}

--- a/backend/app/Http/Controllers/Api/PromotionController.php
+++ b/backend/app/Http/Controllers/Api/PromotionController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Promotion;
+
+class PromotionController extends Controller
+{
+    public function index()
+    {
+        $promotions = Promotion::where('is_active', true)->get();
+        return response()->json($promotions);
+    }
+}

--- a/backend/app/Http/Controllers/Api/ReservationController.php
+++ b/backend/app/Http/Controllers/Api/ReservationController.php
@@ -9,6 +9,7 @@ use App\Jobs\SendReservationReminder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use App\Services\PaymentService;
+use App\Models\LoyaltyPoint;
 
 class ReservationController extends Controller
 {
@@ -47,6 +48,15 @@ class ReservationController extends Controller
 
         SendReservationReminder::dispatch($reservation)
             ->delay($reservation->start_time->subHour());
+
+        $points = (int) floor($price / 10);
+        if ($points > 0) {
+            LoyaltyPoint::create([
+                'user_id' => Auth::id(),
+                'points' => $points,
+                'description' => 'Reserva campo: ' . $field->name,
+            ]);
+        }
 
         return response()->json($reservation, 201);
     }

--- a/backend/app/Models/LoyaltyPoint.php
+++ b/backend/app/Models/LoyaltyPoint.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class LoyaltyPoint extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'points',
+        'description',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/Promotion.php
+++ b/backend/app/Models/Promotion.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Promotion extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+        'points_required',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -68,4 +68,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(Review::class);
     }
+
+    public function loyaltyPoints()
+    {
+        return $this->hasMany(LoyaltyPoint::class);
+    }
 }

--- a/backend/database/migrations/2025_08_20_220100_create_loyalty_points_table.php
+++ b/backend/database/migrations/2025_08_20_220100_create_loyalty_points_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('loyalty_points', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->integer('points');
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('loyalty_points');
+    }
+};

--- a/backend/database/migrations/2025_08_20_220101_create_promotions_table.php
+++ b/backend/database/migrations/2025_08_20_220101_create_promotions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('promotions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->integer('points_required');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('promotions');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,8 @@ use App\Http\Controllers\Api\FieldController;
 use App\Http\Controllers\Api\ReservationController;
 use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\ReviewController;
+use App\Http\Controllers\Api\PromotionController;
+use App\Http\Controllers\Api\LoyaltyController;
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
@@ -16,6 +18,7 @@ Route::get('/fields/{field}', [FieldController::class, 'show']);
 
 Route::get('/reviews', [ReviewController::class, 'index']);
 Route::get('/reviews/{review}', [ReviewController::class, 'show']);
+Route::get('/promotions', [PromotionController::class, 'index']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);
@@ -26,4 +29,6 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/reviews', [ReviewController::class, 'store']);
     Route::put('/reviews/{review}', [ReviewController::class, 'update']);
     Route::delete('/reviews/{review}', [ReviewController::class, 'destroy']);
+    Route::get('/loyalty/balance', [LoyaltyController::class, 'balance']);
+    Route::post('/loyalty/redeem', [LoyaltyController::class, 'redeem']);
 });

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -10,6 +10,7 @@ import FieldListScreen from './screens/FieldListScreen';
 import FieldDetailScreen from './screens/FieldDetailScreen';
 import ReservationsScreen from './screens/ReservationsScreen';
 import FiltersScreen from './screens/FiltersScreen';
+import LoyaltyScreen from './screens/LoyaltyScreen';
 
 const RootStack = createNativeStackNavigator();
 const FieldsStack = createNativeStackNavigator();
@@ -39,6 +40,7 @@ function AppTabs() {
     <Tab.Navigator>
       <Tab.Screen name="Canchas" component={FieldsStackScreen} options={{ headerShown: false }} />
       <Tab.Screen name="Mis reservas" component={ReservationsStackScreen} options={{ headerShown: false }} />
+      <Tab.Screen name="Promos" component={LoyaltyScreen} />
     </Tab.Navigator>
   );
 }

--- a/mobile/screens/LoyaltyScreen.js
+++ b/mobile/screens/LoyaltyScreen.js
@@ -1,0 +1,67 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, FlatList, Button, Alert } from 'react-native';
+import { AuthContext } from '../context/AuthContext';
+
+export default function LoyaltyScreen() {
+  const { token } = useContext(AuthContext);
+  const [balance, setBalance] = useState(0);
+  const [promotions, setPromotions] = useState([]);
+
+  const loadData = () => {
+    fetch('http://localhost:8000/api/promotions')
+      .then(res => res.json())
+      .then(setPromotions)
+      .catch(() => {});
+
+    fetch('http://localhost:8000/api/loyalty/balance', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then(res => res.json())
+      .then(json => setBalance(json.balance || 0))
+      .catch(() => {});
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const redeem = (id) => {
+    fetch('http://localhost:8000/api/loyalty/redeem', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ promotion_id: id }),
+    })
+      .then(res => res.json())
+      .then(json => {
+        if (json.balance !== undefined) {
+          Alert.alert('Promoción canjeada');
+          setBalance(json.balance);
+        } else if (json.message) {
+          Alert.alert(json.message);
+        }
+      })
+      .catch(() => Alert.alert('No se pudo canjear'));
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Saldo: {balance} puntos</Text>
+      <FlatList
+        data={promotions}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <View style={{ marginTop: 12 }}>
+            <Text>{item.name} - {item.points_required} pts</Text>
+            {balance >= item.points_required && (
+              <Button title="Canjear" onPress={() => redeem(item.id)} />
+            )}
+          </View>
+        )}
+        ListEmptyComponent={<Text>No hay promociones</Text>}
+      />
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add LoyaltyPoint and Promotion models with migrations
- expose promotions and loyalty balance/redeem endpoints
- display loyalty balance and promotions in mobile app

## Testing
- `php artisan test` (fails: Tests:    7 failed, 10 warnings, 1 passed (41 assertions))
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65a056fcc8320b2fa7f19c4bec8a3