### PR TITLE
Add role-based policies and route middleware

### DIFF
--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -58,7 +58,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
-            'role' => 'string',
+            'role' => Role::class,
             'provider_claims' => 'array',
         ];
     }

--- a/backend/app/Policies/FieldPolicy.php
+++ b/backend/app/Policies/FieldPolicy.php
@@ -6,9 +6,6 @@ use App\Models\{Field, Role, User};
 
 class FieldPolicy
 {
-    /**
-     * Determine whether the user can create fields.
-     */
     public function create(User $user): bool
     {
         return in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
@@ -23,43 +20,5 @@ class FieldPolicy
     {
         return in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
     }
-    public function update(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function delete(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function update(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function delete(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function update(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function delete(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function update(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
-
-    public function delete(User $user, Field $field): bool
-    {
-        return in_array($user->role, [User::ROLE_ADMIN, User::ROLE_SUPERADMIN], true);
-    }
 }
+

--- a/backend/app/Policies/ReservationPolicy.php
+++ b/backend/app/Policies/ReservationPolicy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\{Reservation, Role, User};
+
+class ReservationPolicy
+{
+    public function create(User $user): bool
+    {
+        return in_array($user->role, [Role::CLIENTE, Role::ADMIN, Role::SUPERADMIN], true);
+    }
+
+    public function update(User $user, Reservation $reservation): bool
+    {
+        return $user->id === $reservation->user_id ||
+            in_array($user->role, [Role::ADMIN, Role::SUPERADMIN], true);
+    }
+
+    public function delete(User $user, Reservation $reservation): bool
+    {
+        return $this->update($user, $reservation);
+    }
+}
+

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,12 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\Api\FieldController;
-use App\Http\Controllers\Api\ReservationController;
-use App\Http\Controllers\Api\AuthController;
-use App\Http\Controllers\Api\ReviewController;
-use App\Http\Controllers\Api\PromotionController;
-use App\Http\Controllers\Api\LoyaltyController;
+use App\Http\Controllers\Api\{AuthController, ChatController, FieldController, LoyaltyController, MessageController, PromotionController, ReservationController, ReviewController, SocialAuthController, UserController};
 
 Route::post('/register', [AuthController::class, 'register']);
 Route::post('/login', [AuthController::class, 'login']);
@@ -15,12 +10,10 @@ Route::get('/auth/{provider}/callback', [SocialAuthController::class, 'callback'
 
 Route::get('/fields', [FieldController::class, 'index']);
 Route::get('/fields/map', [FieldController::class, 'map']);
-Route::post('/fields', [FieldController::class, 'store'])->middleware('auth:sanctum');
-Route::put('/fields/{field}', [FieldController::class, 'update'])->middleware('auth:sanctum');
-Route::delete('/fields/{field}', [FieldController::class, 'destroy'])->middleware('auth:sanctum');
+Route::post('/fields', [FieldController::class, 'store'])->middleware(['auth:sanctum', 'role:admin,superadmin']);
+Route::put('/fields/{field}', [FieldController::class, 'update'])->middleware(['auth:sanctum', 'role:admin,superadmin']);
+Route::delete('/fields/{field}', [FieldController::class, 'destroy'])->middleware(['auth:sanctum', 'role:admin,superadmin']);
 Route::get('/fields/{field}', [FieldController::class, 'show']);
-Route::put('/fields/{field}', [FieldController::class, 'update'])->middleware('auth:sanctum');
-Route::delete('/fields/{field}', [FieldController::class, 'destroy'])->middleware('auth:sanctum');
 
 Route::get('/reviews', [ReviewController::class, 'index']);
 Route::get('/reviews/{review}', [ReviewController::class, 'show']);
@@ -35,12 +28,12 @@ Route::get('/ranking', [UserController::class, 'ranking']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::get('/reservations', [ReservationController::class, 'index']);
-    Route::post('/reservations', [ReservationController::class, 'store']);
+    Route::post('/reservations', [ReservationController::class, 'store'])->middleware('role:cliente,admin,superadmin');
     Route::get('/reservations/{reservation}', [ReservationController::class, 'show']);
     Route::get('/reservations/{reservation}/ics', [ReservationController::class, 'ics']);
-    Route::put('/reservations/{reservation}', [ReservationController::class, 'update']);
-    Route::delete('/reservations/{reservation}', [ReservationController::class, 'destroy']);
-    Route::post('/reservations/{reservation}/pay', [ReservationController::class, 'pay']);
+    Route::put('/reservations/{reservation}', [ReservationController::class, 'update'])->middleware('role:cliente,admin,superadmin');
+    Route::delete('/reservations/{reservation}', [ReservationController::class, 'destroy'])->middleware('role:cliente,admin,superadmin');
+    Route::post('/reservations/{reservation}/pay', [ReservationController::class, 'pay'])->middleware('role:cliente,admin,superadmin');
     Route::post('/reviews', [ReviewController::class, 'store']);
     Route::put('/reviews/{review}', [ReviewController::class, 'update']);
     Route::delete('/reviews/{review}', [ReviewController::class, 'destroy']);


### PR DESCRIPTION
## Summary
- cast user role as enum and enforce via policies
- add field and reservation policies
- secure field and reservation routes with role middleware

## Testing
- `php artisan test` *(fails: Call to undefined method App\Models\Reservation::waitlist())*

------
https://chatgpt.com/codex/tasks/task_e_68a77814fc308320864183347037c5c8